### PR TITLE
Spring: Add Semgrep metavar for exact path/route variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,6 @@ dmypy.json
 
 # Test harness repositories
 harness/
+
+# VSCode
+.vscode/

--- a/routes/commands/viz.py
+++ b/routes/commands/viz.py
@@ -99,6 +99,9 @@ def d3ify(parts, output, result, connectors, _global):
             normalized = normalizer(result)
             connector = connectors.get(normalized)
             fill = connector.rd_fill if connector else result.rd_fill
+        if result.rd_route:
+            name = f"ln {result.start_line}: {result.rd_route}"
+            fill = result.rd_fill
         elif _global:
             fill = _global.rd_fill
         else:

--- a/routes/rules/spring.yml
+++ b/routes/rules/spring.yml
@@ -167,7 +167,7 @@ rules:
       - pattern-either:
           - patterns:
               - pattern: |
-                  @$METHOD(...)
+                  @$METHOD(..., path = $PATH, ...)
                   $RETURNTYPE $FUNC(...) { ... }
               - pattern-not: |
                   @$METHOD(...)

--- a/routes/types.py
+++ b/routes/types.py
@@ -19,6 +19,7 @@ class Framework(enum.Enum):
     CAKEPHP = "cakephp"
     RAILS = "rails"
     GRAPE = "grape"
+    SPRING = "spring"
 
 
 class SemgrepResult:
@@ -65,6 +66,16 @@ class SemgrepResult:
     def rd_type(self):
         return self.rd_metadata.get("type", ResultType.ROUTE.value)
 
+    # Try to extract a route from the result, it's not in the metadata and has to be parsed from the line
+    @property
+    def rd_route(self):
+        if "$PATH" in self.metavars: #For some rules we have extracted a path in the $PATH metavar
+            return "{} {}".format(self.metavars['$METHOD']['abstract_content'], self.metavars['$PATH']['abstract_content'])
+        elif self.rd_type == ResultType.ROUTE.value:
+            return self.first_line
+        else:
+            return None
+    
     @property
     def rd_normalizer(self):
         return self.rd_metadata.get("normalizer")


### PR DESCRIPTION
Adding a $PATH metavar in the rules allows you to really extract the exact values
Only on unauthorized paths for now, I tried also supporting that for the other rules but it would break weirdly

The final graph will show something more readable like:
```
ln 22: PostMapping "/api/book/{bookId}"
```