### PR TITLE
add decorators for FastAPI as well

### DIFF
--- a/routes/rules/fastapi.yml
+++ b/routes/rules/fastapi.yml
@@ -2,18 +2,38 @@ rules:
   - id: fastapi-route-authenticated
     patterns:
       - pattern-either:
-          - pattern: |
-              @$APP.$METHOD($PATH, ...)
-              def $FUNC(..., token, ...):
-                ...
-          - pattern: |
-              @$APP.$METHOD($PATH, ...)
-              def $FUNC(..., current_user, ...):
-                ...
-          - pattern: |
-              @$APP.$METHOD($PATH, ...)
-              def $FUNC(..., auth_result, ...):
-                ...
+        - pattern: |
+            @$APP.$METHOD($PATH, ...)
+            def $FUNC(..., token, ...):
+              ...
+        - pattern: |
+            @$APP.$METHOD($PATH, ...)
+            def $FUNC(..., current_user, ...):
+              ...
+        - pattern: |
+            @$APP.$METHOD($PATH, ...)
+            def $FUNC(..., auth_result, ...):
+              ...
+        - pattern: |
+            @$APP.$METHOD($PATH, ...)
+            @auth_required
+            def $FUNC(...):
+              ...
+        - pattern: |
+            @$APP.$METHOD($PATH, ...)
+            @login_required
+            def $FUNC(...):
+              ...
+        - pattern: |
+            @$APP.$METHOD($PATH, ...)
+            @requires_authentication
+            def $FUNC(...):
+              ...
+        - pattern: |
+            @$APP.$METHOD($PATH, ...)
+            @jwt_required
+            def $FUNC(...):
+              ...
       - metavariable-pattern:
           metavariable: $METHOD
           pattern-either:
@@ -54,6 +74,26 @@ rules:
       - pattern-not: |
           @$APP.$METHOD($PATH, ...)
           def $FUNC(..., auth_result, ...):
+            ...
+      - pattern-not: |
+          @$APP.$METHOD($PATH, ...)
+          @auth_required
+          def $FUNC(...):
+            ...
+      - pattern-not: |
+          @$APP.$METHOD($PATH, ...)
+          @login_required
+          def $FUNC(...):
+            ...
+      - pattern-not: |
+          @$APP.$METHOD($PATH, ...)
+          @requires_authentication
+          def $FUNC(...):
+            ...
+      - pattern-not: |
+          @$APP.$METHOD($PATH, ...)
+          @jwt_required
+          def $FUNC(...):
             ...
       - metavariable-pattern:
           metavariable: $METHOD


### PR DESCRIPTION
Sorry I didn't see that you asked me to review https://github.com/mschwager/route-detect/pull/17.

It is not uncommon in FastAPI to not use the Depends(Security) schema and instead build auth with the old methods used e.g in Flask, using good old decorators.

This PR makes it easy to detect authenticated decorated routes.